### PR TITLE
[WEBDEV-648] Add Statutory Instruments thing route to config

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -6,29 +6,30 @@ if (typeof process.env.THORNEY_HOST != 'undefined' && process.env.THORNEY_HOST !
   host = process.env.THORNEY_HOST;
 }
 
-// Configure the proxy route, this should point to
-// where your back end application runs
+// Configure the proxy routes - these should point to where your back end applications run
 module.exports = {
-  localhost: {
-    default: {
-      host: host,
-      port: 5401
-    }
-  },
-  'beta.parliament.uk':     generateProxyTargets('web1live'),
-  'devci.parliament.uk':    generateProxyTargets('web1devci'),
-  'augustus.pdswebops.org': generateProxyTargets('pdswebops')
+  localhost:                generateProxyTargets(host, 5401, 'imaginaryHost'),
+  'beta.parliament.uk':     generateProxyTargets('thorney.web1live.org', 3000, 'parliamentuk-green.web1live.org'),
+  'devci.parliament.uk':    generateProxyTargets('thorney.web1devci.org', 3000, 'parliamentuk-green.web1devci.org'),
+  'augustus.pdswebops.org': generateProxyTargets('thorney.pdswebops.org', 3000, 'parliamentuk-green.pdswebops.org')
 };
 
-function generateProxyTargets (hostname) {
+function generateProxyTargets (host, port, defaultHost) {
   return {
-    "/^\\/search/": {
-      host: `thorney.${hostname}.org`,
-      port: 3000
+    // Match requests to /search
+    '/^\\/search/': {
+      host: host,
+      port: port
     },
+    // Match requests to /statutory-instruments/<8_character_alphanumeric_id>
+    '/^\\/statutory-instruments\\/[a-zA-z0-9]{8}$/': {
+      host: host,
+      port: port
+    },
+    // All other requests go here
     default: {
-      host: `parliamentuk-green.${hostname}.org`,
+      host: defaultHost,
       port: 80
     }
   }
-}
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1591,10 +1591,10 @@
           "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.1"
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.2"
           }
         },
         "ansi-regex": {
@@ -1609,7 +1609,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
@@ -1618,9 +1618,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
           }
         },
         "fast-deep-equal": {
@@ -1647,7 +1647,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -7012,12 +7012,12 @@
           "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
           "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
           "requires": {
-            "async": "~1.0.0",
-            "colors": "1.0.x",
-            "cycle": "1.0.x",
-            "eyes": "0.1.x",
-            "isstream": "0.1.x",
-            "stack-trace": "0.0.x"
+            "async": "1.0.0",
+            "colors": "1.0.3",
+            "cycle": "1.0.3",
+            "eyes": "0.1.8",
+            "isstream": "0.1.2",
+            "stack-trace": "0.0.10"
           },
           "dependencies": {
             "async": {
@@ -7642,7 +7642,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
           "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
           "requires": {
-            "lodash": "^4.8.0"
+            "lodash": "4.17.10"
           }
         },
         "request": {
@@ -7650,28 +7650,28 @@
           "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
           "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.6.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.1",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.1",
-            "har-validator": "~5.0.3",
-            "hawk": "~6.0.2",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.17",
-            "oauth-sign": "~0.8.2",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.1",
-            "safe-buffer": "^5.1.1",
-            "stringstream": "~0.0.5",
-            "tough-cookie": "~2.3.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.1.0"
+            "aws-sign2": "0.7.0",
+            "aws4": "1.7.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.2",
+            "safe-buffer": "5.1.2",
+            "stringstream": "0.0.6",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
           }
         }
       }

--- a/test/config/routes.spec.js
+++ b/test/config/routes.spec.js
@@ -2,13 +2,72 @@ const expect = require('chai').expect
 const proxyquire = require('proxyquire').noPreserveCache()
 
 describe('routes', () => {
+  let routesExpectation = {
+    localhost: {
+      default: {
+        host: 'imaginaryHost',
+        port: 80
+      },
+      '/^\\/search/': {
+        host: 'localhost',
+        port: 5401
+      },
+      '/^\\/statutory-instruments\\/[a-zA-z0-9]{8}$/': {
+        "host": 'localhost',
+        "port": 5401
+      },
+    },
+    'beta.parliament.uk': {
+      '/^\\/search/': {
+        host: 'thorney.web1live.org',
+        port: 3000
+      },
+      '/^\\/statutory-instruments\\/[a-zA-z0-9]{8}$/': {
+        host: 'thorney.web1live.org',
+        port: 3000
+      },
+      default: {
+        host: 'parliamentuk-green.web1live.org',
+        port: 80
+      }
+    },
+    'devci.parliament.uk': {
+      '/^\\/search/': {
+        host: 'thorney.web1devci.org',
+        port: 3000
+      },
+      '/^\\/statutory-instruments\\/[a-zA-z0-9]{8}$/': {
+        host: 'thorney.web1devci.org',
+        port: 3000
+      },
+      default: {
+        host: 'parliamentuk-green.web1devci.org',
+        port: 80
+      }
+    },
+    'augustus.pdswebops.org': {
+      '/^\\/search/': {
+        host: 'thorney.pdswebops.org',
+        port: 3000
+      },
+      '/^\\/statutory-instruments\\/[a-zA-z0-9]{8}$/': {
+        host: 'thorney.pdswebops.org',
+        port: 3000
+      },
+      default: {
+        host: 'parliamentuk-green.pdswebops.org',
+        port: 80
+      }
+    }
+  };
+
   describe('when THORNEY_HOST is not defined', () => {
     it('routes.localhost.default.host is "localhost"', () => {
       delete process.env['THORNEY_HOST'];
 
       const routes = proxyquire('../../config/routes', {});
 
-      expect(routes.localhost.default.host).to.eq('localhost');
+      expect(routes).to.deep.equal(routesExpectation);
     })
   })
 
@@ -16,9 +75,12 @@ describe('routes', () => {
     it('routes.localhost.default.host is "thorney"', () => {
       process.env['THORNEY_HOST'] = 'thorney';
 
+      routesExpectation.localhost['/^\\/search/'].host = 'thorney';
+      routesExpectation.localhost['/^\\/statutory-instruments\\/[a-zA-z0-9]{8}$/'].host = 'thorney';
+
       const routes = proxyquire('../../config/routes', {});
 
-      expect(routes.localhost.default.host).to.eq('thorney');
+      expect(routes).to.deep.equal(routesExpectation);
     })
   })
 })


### PR DESCRIPTION
- Use regex to strictly only match /statutory-instruments/<8_character_alphanumeric_id>
- Add 'imaginaryHost' which allows us to easily check the regex locally
- Update generateProxyTargets function in config/routes.js to be more generic
- Update test/config/routes.spec.js