### PR TITLE
[WEBDEV-689] Replace i18n with i18next

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
 - [Running the application](#running-the-application)
 - [Using components](#using-components)
 - [Starting Augustus and Shunter serve in a Docker Image](#starting-augustus-and-shunter-serve-in-a-docker-image)
-- [i18n Note](#i18n-note)
+- [i18next Note](#i18next-note)
+  - [Double moustaches](#double-moustaches)
+  - [Prefixing the variable name with a hyphen](#prefixing-the-variable-name-with-a-hyphen)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -67,16 +69,26 @@ docker-compose up
 ```
 The application will then be available from http://localhost/.
 
-## i18n Note
-Please note, that while normally data would be passed into a string in a translation file using double moustaches which sanitises input, when passing in a URL or other form of content which you do not wish to be sanitised you must use triple moustaches or it will not be rendered correctly in the output. For example:
+## i18next Note
+Passing in data to the translation with double moustaches sanitises input. If you wish to pass in a URL or other data that you do not wish to be sanitised, for it be rendered correctly you must prefix the variable name with a hyphen. For example:
 
-```
-"cookie-policy": "<a href='{{{link}}}'>Cookie Policy</a>"
+### Double moustaches
+The following translation:
+```json
+"cookie-policy": "<a href='{{link}}'>Cookie Policy</a>"
+```  
+Will be rendered incorrectly as:  
+```html
+<a href='*&meta*&cookie'>Cookie Policy</a>
 ```  
 
-Will be rendered correctly as:  
-
+### Prefixing the variable name with a hyphen
+The following translation:
+```json
+"cookie-policy": "<a href='{{-link}}'>Cookie Policy</a>"
 ```
+Will be rendered correctly as:  
+```html
 <a href='/meta/cookie'>Cookie Policy</a>
 ```
 

--- a/config.js
+++ b/config.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const i18n = require('./config/i18n');
+const i18next = require('./config/i18next');
 const shunter = require('./config/shunter');
 
 const moduleName = 'pugin-components';
 
 module.exports = {
-  i18n,
+  i18next,
   moduleName,
   shunter
 };

--- a/config/i18n.js
+++ b/config/i18n.js
@@ -1,5 +1,0 @@
-module.exports = {
-  directory: __dirname + '/../locales',
-  objectNotation: true,
-  updateFiles: false,
-};

--- a/config/i18next.js
+++ b/config/i18next.js
@@ -1,0 +1,12 @@
+const en = require('../locales/en');
+
+module.exports = {
+  lng: 'en',
+  debug: false,
+  nsSeparator: false,
+  resources: {
+    en: {
+      translation: en
+    }
+  }
+}

--- a/dust/t.js
+++ b/dust/t.js
@@ -1,21 +1,27 @@
 'use strict';
 
-const i18n = require('i18n');
+const i18next = require('i18next');
 
-i18n.configure(require('../config/i18n'));
+i18next.init(require('../config').i18next);
 
 module.exports = initHelper;
-/**
-* This helper allows dust to work with the i18n internationalization package.
-* It passes in parameters which are accessable through the params object, the dust helper then takes in those parameters as its own.
-*/
-function initHelper(dust) {
-  dust.helpers.t = function (chunk, ctx, bodies, params) {
-    let key = dust.helpers.tap(params.key, chunk, ctx);
+module.exports.createTHelper = createTHelper;
 
-    let data = dust.helpers.tap(params.data, chunk, ctx);
+// This helper allows dust to work with the i18next internationalization package.
+// It passes in parameters which are accessable through the params object, the dust helper then takes in those parameters as its own.
+function createTHelper(dustObject) {
+  return function (chunk, ctx, bodies, params) {
+    let key = dustObject.helpers.tap(params.key, chunk, ctx);
+
+    let data = dustObject.helpers.tap(params.data, chunk, ctx);
     data = data ? data : {};
 
-    return chunk.write(i18n.__(key, data));
+    return chunk.write(i18next.t(key, data));
   };
+}
+
+// This function is exported and loaded by Shunter to be used as a helper in dust.
+// It is in a format that Shunter expects, however the last parameter is added so that we can test it.
+function initHelper(dust, paramTwo, paramThree, tHelper = createTHelper) {
+  dust.helpers.t = tHelper(dust);
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -5,14 +5,14 @@
 		},
 		"header": {
 			"skip-to-content": "Skip to main content",
-			"cookie-banner-text": "Parliament.uk uses cookies to make the site simpler. <a href='{{{link}}}'>Find out more about cookies</a>",
+			"cookie-banner-text": "Parliament.uk uses cookies to make the site simpler. <a href='{{-link}}'>Find out more about cookies</a>",
 			"beta-status": "These pages are being tested. <a href='http://www.smartsurvey.co.uk/s/ukparliament-beta-website-feedback/'>Give feedback</a> to help improve them. Go to <a href='http://www.parliament.uk'>current website</a>",
 			"label": "UK Parliament"
 		},
 		"footer": {
 			"uk-parliament": "UK Parliament",
 			"current-website": "<a href='http://www.parliament.uk'>Current Parliament.uk website</a>",
-			"cookie-policy": "<a href='{{{link}}}'>Cookie Policy</a>",
+			"cookie-policy": "<a href='{{-link}}'>Cookie Policy</a>",
 			"data-protection-privacy": "<a href='https://www.parliament.uk/site-information/data-protection/data-protection-and-privacy-policy/'>Data protection and privacy policy</a>"
 		},
 		"number-navigation": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -244,36 +244,6 @@
         "repeat-string": "1.6.1"
       }
     },
-    "ambi": {
-      "version": "2.5.0",
-      "resolved": "http://registry.npmjs.org/ambi/-/ambi-2.5.0.tgz",
-      "integrity": "sha1-fI43K+SIkRV+fOoBy2+RQ9H3QiA=",
-      "requires": {
-        "editions": "1.3.4",
-        "typechecker": "4.6.0"
-      },
-      "dependencies": {
-        "typechecker": {
-          "version": "4.6.0",
-          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.6.0.tgz",
-          "integrity": "sha512-83OrXpyP3LNr7aRbLkt2nkjE/d7q8su8/uRvrKxCpswqVCVGOgyaKpaz8/MTjQqBYe4eLNuJ44pNakFZKqyPMA==",
-          "requires": {
-            "editions": "2.0.2"
-          },
-          "dependencies": {
-            "editions": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/editions/-/editions-2.0.2.tgz",
-              "integrity": "sha512-0B8aSTWUu9+JW99zHoeogavCi+lkE5l35FK0OKe0pCobixJYoeof3ZujtqYzSsU2MskhRadY5V9oWUuyG4aJ3A==",
-              "requires": {
-                "errlop": "1.0.3",
-                "semver": "5.5.0"
-              }
-            }
-          }
-        }
-      }
-    },
     "ansi-escapes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
@@ -1221,11 +1191,6 @@
         }
       }
     },
-    "csextends": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/csextends/-/csextends-1.2.0.tgz",
-      "integrity": "sha512-S/8k1bDTJIwuGgQYmsRoE+8P+ohV32WhQ0l4zqrc0XDdxOhjQQD7/wTZwCzoZX53jSX3V/qwjT+OkPTxWQcmjg=="
-    },
     "css-select": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
@@ -1423,14 +1388,6 @@
         "glob": "6.0.4"
       }
     },
-    "eachr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/eachr/-/eachr-2.0.4.tgz",
-      "integrity": "sha1-Rm98qhBwj2EFCeMsgHqv5X/BIr8=",
-      "requires": {
-        "typechecker": "2.1.0"
-      }
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1440,11 +1397,6 @@
         "jsbn": "0.1.1",
         "safer-buffer": "2.1.2"
       }
-    },
-    "editions": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
     },
     "editorconfig": {
       "version": "0.15.0",
@@ -1493,14 +1445,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
-    },
-    "errlop": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/errlop/-/errlop-1.0.3.tgz",
-      "integrity": "sha512-5VTnt0yikY4LlQEfCXVSqfE6oLj1HVM4zVSvAKMnoYjL/zrb6nqiLowZS4XlG7xENfyj7lpYWvT+wfSCr6dtlA==",
-      "requires": {
-        "editions": "1.3.4"
-      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -1758,21 +1702,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
-    "extendr": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/extendr/-/extendr-2.1.0.tgz",
-      "integrity": "sha1-MBqgu+pWX00tyPVw8qImEahSe1Y=",
-      "requires": {
-        "typechecker": "2.0.8"
-      },
-      "dependencies": {
-        "typechecker": {
-          "version": "2.0.8",
-          "resolved": "http://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
-          "integrity": "sha1-6D2oS7ZMWEzLNFg4V2xAsDN9uC4="
-        }
-      }
-    },
     "external-editor": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
@@ -1790,21 +1719,6 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "requires": {
         "is-extglob": "1.0.0"
-      }
-    },
-    "extract-opts": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-2.2.0.tgz",
-      "integrity": "sha1-H6KOunNSxttID4hc63GkaBC+bX0=",
-      "requires": {
-        "typechecker": "2.0.8"
-      },
-      "dependencies": {
-        "typechecker": {
-          "version": "2.0.8",
-          "resolved": "http://registry.npmjs.org/typechecker/-/typechecker-2.0.8.tgz",
-          "integrity": "sha1-6D2oS7ZMWEzLNFg4V2xAsDN9uC4="
-        }
       }
     },
     "extsprintf": {
@@ -2863,18 +2777,10 @@
         "debug": "3.1.0"
       }
     },
-    "i18n": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/i18n/-/i18n-0.8.3.tgz",
-      "integrity": "sha1-LYzxwkciYCwgQdAbpq5eqlE4jw4=",
-      "requires": {
-        "debug": "3.1.0",
-        "make-plural": "3.0.6",
-        "math-interval-parser": "1.1.0",
-        "messageformat": "0.3.1",
-        "mustache": "2.3.1",
-        "sprintf-js": "1.1.1"
-      }
+    "i18next": {
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-11.9.0.tgz",
+      "integrity": "sha512-NDuIoELzyJ+29kc29j9aKgzjZht4kEKh3PPdz0qCEC9ZUpgRVaWUdkMRES/NVTcpe1ei4MMwY8DNWBWCIUlAng=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -2895,20 +2801,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
-    },
-    "ignorefs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ignorefs/-/ignorefs-1.2.0.tgz",
-      "integrity": "sha1-2ln7hYl25KXkNwLM0fKC/byeV1Y=",
-      "requires": {
-        "editions": "1.3.4",
-        "ignorepatterns": "1.1.0"
-      }
-    },
-    "ignorepatterns": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ignorepatterns/-/ignorepatterns-1.1.0.tgz",
-      "integrity": "sha1-rI9DbyI5td+2bV8NOpBKh6xnzF4="
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -3586,14 +3478,6 @@
         "yallist": "2.1.2"
       }
     },
-    "make-plural": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-3.0.6.tgz",
-      "integrity": "sha1-IDOgO6wpC487uRJY9lud9+iwHKc=",
-      "requires": {
-        "minimist": "1.2.0"
-      }
-    },
     "marked": {
       "version": "0.3.19",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
@@ -3607,14 +3491,6 @@
       "dev": true,
       "requires": {
         "minimatch": "3.0.4"
-      }
-    },
-    "math-interval-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-1.1.0.tgz",
-      "integrity": "sha1-2+2lsGsySZc8bfYXD94jhvCv2JM=",
-      "requires": {
-        "xregexp": "2.0.0"
       }
     },
     "math-random": {
@@ -3632,18 +3508,6 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
-    },
-    "messageformat": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-0.3.1.tgz",
-      "integrity": "sha1-5Y//gkXps5cXmeW0PbWLPpQX9aI=",
-      "requires": {
-        "async": "1.5.2",
-        "glob": "6.0.4",
-        "make-plural": "3.0.6",
-        "nopt": "3.0.6",
-        "watchr": "2.4.13"
-      }
     },
     "micromatch": {
       "version": "2.3.11",
@@ -3850,7 +3714,8 @@
     "mustache": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.1.tgz",
-      "integrity": "sha512-20dW38oeiTzauvbxs1YxQbr3gbu/Lfo15J4V0EqbspYnn/GwSeTSDNtESy2nak28BW0k8qp7dnrFhrsejLPUtw=="
+      "integrity": "sha512-20dW38oeiTzauvbxs1YxQbr3gbu/Lfo15J4V0EqbspYnn/GwSeTSDNtESy2nak28BW0k8qp7dnrFhrsejLPUtw==",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -3904,14 +3769,6 @@
         "propagate": "1.0.0",
         "qs": "6.5.2",
         "semver": "5.5.0"
-      }
-    },
-    "nopt": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "requires": {
-        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -6862,14 +6719,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
-    "safefs": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/safefs/-/safefs-3.2.2.tgz",
-      "integrity": "sha1-gXDBRE1wOOCMrqBaN0+uL6NJ4Vw=",
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
-    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -6887,16 +6736,6 @@
       "integrity": "sha512-jlX3FGdWvYf4Q3LFfFWS1QvPg3IGCGWxIc8QBFdPTbpTJnt/v17FHXYVAn7C8sHf1yUXo2c7yIM0isDryfYtHQ==",
       "requires": {
         "https-proxy-agent": "2.2.1"
-      }
-    },
-    "scandirectory": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/scandirectory/-/scandirectory-2.5.0.tgz",
-      "integrity": "sha1-bOA/VKCQtmjjy+2/IO354xBZPnI=",
-      "requires": {
-        "ignorefs": "1.2.0",
-        "safefs": "3.2.2",
-        "taskgroup": "4.3.1"
       }
     },
     "semver": {
@@ -7182,11 +7021,6 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
       "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
     },
-    "sprintf-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
-    },
     "sshpk": {
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
@@ -7374,15 +7208,6 @@
         "xtend": "4.0.1"
       }
     },
-    "taskgroup": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/taskgroup/-/taskgroup-4.3.1.tgz",
-      "integrity": "sha1-feGT/r12gnPEV3MElwJNUSwnkVo=",
-      "requires": {
-        "ambi": "2.5.0",
-        "csextends": "1.2.0"
-      }
-    },
     "text-encoding": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
@@ -7472,11 +7297,6 @@
         "media-typer": "0.3.0",
         "mime-types": "2.1.19"
       }
-    },
-    "typechecker": {
-      "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/typechecker/-/typechecker-2.1.0.tgz",
-      "integrity": "sha1-0cIJOlT/ihn1jP+HfuqlTyJC04M="
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -7617,21 +7437,6 @@
       "requires": {
         "ensure-posix-path": "1.0.2",
         "matcher-collection": "1.0.5"
-      }
-    },
-    "watchr": {
-      "version": "2.4.13",
-      "resolved": "https://registry.npmjs.org/watchr/-/watchr-2.4.13.tgz",
-      "integrity": "sha1-10hHu01vkPYf4sdPn2hmKqDgdgE=",
-      "requires": {
-        "eachr": "2.0.4",
-        "extendr": "2.1.0",
-        "extract-opts": "2.2.0",
-        "ignorefs": "1.2.0",
-        "safefs": "3.2.2",
-        "scandirectory": "2.5.0",
-        "taskgroup": "4.3.1",
-        "typechecker": "2.1.0"
       }
     },
     "wd": {
@@ -7790,11 +7595,6 @@
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
       "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
       "dev": true
-    },
-    "xregexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
-      "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM="
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "applicationinsights": "^1.0.4",
-    "i18n": "^0.8.3",
+    "i18next": "^11.8.0",
     "morgan": "^1.9.0",
     "pugin-components": "^0.6.7",
     "shunter": "^4.12.0",

--- a/test/dust/t.spec.js
+++ b/test/dust/t.spec.js
@@ -1,0 +1,47 @@
+const chai = require('chai');
+const expect = chai.expect;
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+const initHelper = require('../../dust/t');
+const createTHelper = require('../../dust/t').createTHelper;
+
+chai.use(sinonChai);
+
+describe('translation helper', () => {
+  let dust;
+
+  beforeEach(() => {
+    dust = {
+      helpers: { tap: (param) => { return param } }
+    };
+  });
+
+  describe('#initHelper', () => {
+    it('sets the t helper correctly', () => {
+      let tHelper = () => { return 'tHelper'; };
+
+      initHelper(dust, 'paramTwo', 'paramTwo', tHelper);
+
+      expect(dust.helpers.t).to.eq('tHelper');
+    })
+  });
+
+  describe('#createTHelper', () => {
+    let tHelper, chunk, params;
+
+    before(() => {
+      tHelper = createTHelper(dust);
+
+      chunk = { write: (param) => { return param } };
+
+      params = { key: 'shared.header.cookie-banner-text', data: { link: '/some-link' } };
+    });
+
+    it('calls the right methods and returns the right translation', () => {
+      const expected = 'Parliament.uk uses cookies to make the site simpler. <a href=\'/some-link\'>Find out more about cookies</a>';
+
+      expect(tHelper(chunk, 'ctx', 'bodies', params)).to.eq(expected);
+    });
+  });
+});


### PR DESCRIPTION
- i18n did not ignore colons when they were sent in strings, this replacement fixes that
- It changes the way we tell it to not sanitise links, which is detailed in the README