### PR TITLE
[WEBDEV-816] Update testHelper#createFixture

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "js-beautify": "^1.8.1",
     "jsdoc": "^3.5.5",
     "lighthouse-ci": "^1.2.1",
+    "mkdirp": "^0.5.1",
     "mocha": "^5.2.0",
     "mock-require": "^3.0.2",
     "nock": "^9.6.1",

--- a/test/helpers/test-helper.js
+++ b/test/helpers/test-helper.js
@@ -3,6 +3,7 @@ const fixtureHelper = require('./fixture-helper');
 const paths = require('./walk-helper');
 const expect = require('chai').expect;
 const fs = require('fs');
+const mkdirp = require('mkdirp');
 const b = require('js-beautify').html;
 
 module.exports = {
@@ -66,6 +67,17 @@ module.exports = {
 
     shunterTestHelper.render(layout, jsonFixture, function(error, dom, output){
       let htmlFixture = fixtureHelper.getHtmlFixturePath(fileName, fixtureLocation, integrationTest);
+
+      // Create the directory if it doesn't exist
+      if (!(fs.existsSync(htmlFixture))) {
+        let nonExistentPath = htmlFixture;
+
+        nonExistentPath = nonExistentPath.split('/');
+        nonExistentPath.pop();
+        nonExistentPath = nonExistentPath.join('/');
+
+        mkdirp.sync(nonExistentPath);
+      }
 
       fs.writeFileSync(htmlFixture, b(output));
     });


### PR DESCRIPTION
This update enables `#createFixture` to create directories if they don't exist. This is especially useful because we now have subsidiary resources, which means our static data is nested within directories.