### PR TITLE
[WEBDEV-851] Create link for Groups, SI and PNSI subsidiary resources

### DIFF
--- a/data/groups/12345678.json
+++ b/data/groups/12345678.json
@@ -151,16 +151,9 @@
     "name": "section__section",
     "data": {
       "components": [{
-        "name": "heading",
-        "data": {
-          "translation": {
-            "key": "groups.current.literals"
-          },
-          "size": 2
-        }
-      }, {
         "name": "list__description",
         "data": {
+          "meta": true,
           "items": [{
             "term": {
               "content": "Name"
@@ -178,182 +171,13 @@
           }]
         }
       }, {
-        "name": "heading",
-        "data": {
-          "translation": {
-            "key": "groups.current.objects"
-          },
-          "size": 2
-        }
-      }, {
-        "name": "list__generic",
-        "data": {
-          "type": "ol",
-          "display": {
-            "name": "partials__display",
-            "data": [{
-              "component": "list",
-              "variant": "block"
-            }]
-          },
-          "components": [{
-            "name": "card__generic",
-            "data": {
-              "card-type": "small",
-              "heading": {
-                "name": "heading",
-                "data": {
-                  "content": "School Teachers' Pay and Conditions Order 2018",
-                  "size": 2,
-                  "link": "/statutory-instruments/12345678"
-                }
-              },
-              "list-description": {
-                "name": "list__description",
-                "data": {
-                  "items": [{
-                    "term": {
-                      "content": "laid-thing.laid-date"
-                    },
-                    "description": [{
-                      "content": "14 September 2018"
-                    }]
-                  }]
-                }
-              }
-            }
-          }, {
-            "name": "card__generic",
-            "data": {
-              "card-type": "small",
-              "heading": {
-                "name": "heading",
-                "data": {
-                  "content": "Adoption and Children Act Register (Search and Inspection) (Amendment) Regulations 2018",
-                  "size": 2,
-                  "link": "/statutory-instruments/12345678"
-                }
-              },
-              "list-description": {
-                "name": "list__description",
-                "data": {
-                  "items": [{
-                    "term": {
-                      "content": "laid-thing.laid-date"
-                    },
-                    "description": [{
-                      "content": "12 September 2018"
-                    }]
-                  }]
-                }
-              }
-            }
-          }, {
-            "name": "card__generic",
-            "data": {
-              "card-type": "small",
-              "heading": {
-                "name": "heading",
-                "data": {
-                  "content": "Further Education Bodies (Insolvency) Regulations 2018 ",
-                  "size": 2,
-                  "link": "/statutory-instruments/12345678"
-                }
-              },
-              "list-description": {
-                "name": "list__description",
-                "data": {
-                  "items": [{
-                    "term": {
-                      "content": "laid-thing.laid-date"
-                    },
-                    "description": [{
-                      "content": "5 September 2018"
-                    }]
-                  }]
-                }
-              }
-            }
-          }, {
-            "name": "card__generic",
-            "data": {
-              "card-type": "small",
-              "heading": {
-                "name": "heading",
-                "data": {
-                  "content": "Apprenticeships (Modification to the Specification of Apprenticeship Standards for England) Order 2018",
-                  "size": 2,
-                  "link": "/statutory-instruments/12345678"
-                }
-              },
-              "list-description": {
-                "name": "list__description",
-                "data": {
-                  "items": [{
-                    "term": {
-                      "content": "laid-thing.laid-date"
-                    },
-                    "description": [{
-                      "content": "31 August 2018"
-                    }]
-                  }]
-                }
-              }
-            }
-          }, {
-            "name": "card__generic",
-            "data": {
-              "card-type": "small",
-              "heading": {
-                "name": "heading",
-                "data": {
-                  "content": "School Teachers' Incentive Payments (England) Order 2018",
-                  "size": 2,
-                  "link": "/statutory-instruments/12345678"
-                }
-              },
-              "list-description": {
-                "name": "list__description",
-                "data": {
-                  "items": [{
-                    "term": {
-                      "content": "laid-thing.laid-date"
-                    },
-                    "description": [{
-                      "content": "13 August 2018"
-                    }]
-                  }]
-                }
-              }
-            }
-          }, {
-            "name": "card__generic",
-            "data": {
-              "card-type": "small",
-              "heading": {
-                "name": "heading",
-                "data": {
-                  "content": "Higher Education (Basic Amount and Higher Amount) (England) (Amendment) Regulations 2018",
-                  "size": 2,
-                  "link": "/statutory-instruments/12345678"
-                }
-              },
-              "list-description": {
-                "name": "list__description",
-                "data": {
-                  "items": [{
-                    "term": {
-                      "content": "laid-thing.laid-date"
-                    },
-                    "description": [{
-                      "content": "4 April 2018"
-                    }]
-                  }]
-                }
-              }
-            }
-          }]
-        }
+        "name": "paragraph",
+        "data": [{
+          "content": "groups.subsidiary-resources.layings",
+          "data": {
+            "link": "/groups/12345678/made-available/availability-types/layings"
+          }
+        }]
       }]
     }
   }],

--- a/locales/en.json
+++ b/locales/en.json
@@ -117,6 +117,9 @@
     "layings": {
       "date": "Laid Date: {{-date}}",
       "type": "Type: {{-type}}"
-    }
+    },
+		"subsidiary-resources": {
+			"layings": "<a href= '{{-link}}'>Layings</a>"
+		}
   }
 }

--- a/test/fixtures/html/integration/groups/12345678.html
+++ b/test/fixtures/html/integration/groups/12345678.html
@@ -146,74 +146,11 @@
         </div>
         <section>
             <div class="container">
-                <h2>Literals</h2>
-                <dl><dt>Name</dt>
+                <dl class="meta"><dt>Name</dt>
                     <dd>Department for Education</dd><dt>Start Date</dt>
                     <dd>12 May 2010</dd>
                 </dl>
-                <h2>Objects</h2>
-                <ol class="list--block ">
-                    <li>
-                        <div class="card--small">
-                            <div class="card__details">
-                                <h2><a href="/statutory-instruments/12345678">School Teachers' Pay and Conditions Order 2018</a></h2>
-                                <dl><dt>Laying date</dt>
-                                    <dd>14 September 2018</dd>
-                                </dl>
-                            </div>
-                        </div>
-                    </li>
-                    <li>
-                        <div class="card--small">
-                            <div class="card__details">
-                                <h2><a href="/statutory-instruments/12345678">Adoption and Children Act Register (Search and Inspection) (Amendment) Regulations 2018</a></h2>
-                                <dl><dt>Laying date</dt>
-                                    <dd>12 September 2018</dd>
-                                </dl>
-                            </div>
-                        </div>
-                    </li>
-                    <li>
-                        <div class="card--small">
-                            <div class="card__details">
-                                <h2><a href="/statutory-instruments/12345678">Further Education Bodies (Insolvency) Regulations 2018 </a></h2>
-                                <dl><dt>Laying date</dt>
-                                    <dd>5 September 2018</dd>
-                                </dl>
-                            </div>
-                        </div>
-                    </li>
-                    <li>
-                        <div class="card--small">
-                            <div class="card__details">
-                                <h2><a href="/statutory-instruments/12345678">Apprenticeships (Modification to the Specification of Apprenticeship Standards for England) Order 2018</a></h2>
-                                <dl><dt>Laying date</dt>
-                                    <dd>31 August 2018</dd>
-                                </dl>
-                            </div>
-                        </div>
-                    </li>
-                    <li>
-                        <div class="card--small">
-                            <div class="card__details">
-                                <h2><a href="/statutory-instruments/12345678">School Teachers' Incentive Payments (England) Order 2018</a></h2>
-                                <dl><dt>Laying date</dt>
-                                    <dd>13 August 2018</dd>
-                                </dl>
-                            </div>
-                        </div>
-                    </li>
-                    <li>
-                        <div class="card--small">
-                            <div class="card__details">
-                                <h2><a href="/statutory-instruments/12345678">Higher Education (Basic Amount and Higher Amount) (England) (Amendment) Regulations 2018</a></h2>
-                                <dl><dt>Laying date</dt>
-                                    <dd>4 April 2018</dd>
-                                </dl>
-                            </div>
-                        </div>
-                    </li>
-                </ol>
+                <p><a href='/groups/12345678/made-available/availability-types/layings'>Layings</a></p>
             </div>
         </section>
     </main>


### PR DESCRIPTION
- Removed subheadings 'Literals' and 'Objects'
- Added CSS class 'meta' to the definition list
- Added link to in `/groups/:id` to go to `/groups/:id/made-available/availability-types/layings`