### PR TITLE
[WEBDEV-859] Add routes for groups

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -21,14 +21,26 @@ module.exports = {
 
 function generateProxyTargets (host, port, defaultHost, defaultPort) {
   return {
-    // Match requests to /search
-    '/^\\/search/': {
+    // Match requests to / for the home page. Note: this regex effectively blocks the use of ?json=true as it is strict.
+    '/^\\/$/': {
       host: host,
       port: port
     },
 
-    // Match requests to /statutory-instruments/<8_character_alphanumeric_id>
-    '/^\\/statutory-instruments\\/[a-zA-z0-9]{8}$/': {
+    // Match requests to /groups
+    '/^\\/groups\\/?$/': {
+      host: host,
+      port: port
+    },
+
+    // Match requests to /groups/<8_character_alphanumeric_id>
+    '/^\\/groups\\/[a-zA-z0-9]{8}\\/?$/': {
+      host: host,
+      port: port
+    },
+
+    // Match requests to /groups/<8_character_alphanumeric_id>/made-available/availability-types/layings
+    '/^\\/groups\\/[a-zA-z0-9]{8}/made-available/availability-types/layings\\/?$/': {
       host: host,
       port: port
     },
@@ -39,9 +51,14 @@ function generateProxyTargets (host, port, defaultHost, defaultPort) {
       port: port
     },
 
+    // Match requests to /search
+    '/^\\/search/': {
+      host: host,
+      port: port
+    },
 
-    // Match requests to / for the home page. Note: this regex effectively blocks the use of ?json=true as it is strict.
-    '/^\\/$/': {
+    // Match requests to /statutory-instruments/<8_character_alphanumeric_id>
+    '/^\\/statutory-instruments\\/[a-zA-z0-9]{8}\\/?$/': {
       host: host,
       port: port
     },

--- a/test/config/routes.spec.js
+++ b/test/config/routes.spec.js
@@ -10,7 +10,19 @@ describe('routes', () => {
       }
     },
     'beta.parliament.uk': {
-      '/^\\/statutory-instruments\\/[a-zA-z0-9]{8}$/': {
+      '/^\\/$/': {
+        host: 'thorney.web1live.org',
+        port: 3000
+      },
+      '/^\\/groups\\/?$/': {
+        host: 'thorney.web1live.org',
+        port: 3000
+      },
+      '/^\\/groups\\/[a-zA-z0-9]{8}\\/?$/': {
+        host: 'thorney.web1live.org',
+        port: 3000
+      },
+      '/^\\/groups\\/[a-zA-z0-9]{8}/made-available/availability-types/layings\\/?$/': {
         host: 'thorney.web1live.org',
         port: 3000
       },
@@ -22,7 +34,7 @@ describe('routes', () => {
         host: 'thorney.web1live.org',
         port: 3000
       },
-      '/^\\/$/': {
+      '/^\\/statutory-instruments\\/[a-zA-z0-9]{8}\\/?$/': {
         host: 'thorney.web1live.org',
         port: 3000
       },
@@ -32,7 +44,19 @@ describe('routes', () => {
       }
     },
     'devci.parliament.uk': {
-      '/^\\/statutory-instruments\\/[a-zA-z0-9]{8}$/': {
+      '/^\\/$/': {
+        host: 'thorney.web1devci.org',
+        port: 3000
+      },
+      '/^\\/groups\\/?$/': {
+        host: 'thorney.web1devci.org',
+        port: 3000
+      },
+      '/^\\/groups\\/[a-zA-z0-9]{8}\\/?$/': {
+        host: 'thorney.web1devci.org',
+        port: 3000
+      },
+      '/^\\/groups\\/[a-zA-z0-9]{8}/made-available/availability-types/layings\\/?$/': {
         host: 'thorney.web1devci.org',
         port: 3000
       },
@@ -44,7 +68,7 @@ describe('routes', () => {
         host: 'thorney.web1devci.org',
         port: 3000
       },
-      '/^\\/$/': {
+      '/^\\/statutory-instruments\\/[a-zA-z0-9]{8}\\/?$/': {
         host: 'thorney.web1devci.org',
         port: 3000
       },
@@ -54,7 +78,19 @@ describe('routes', () => {
       }
     },
     'augustus.pdswebops.org': {
-      '/^\\/statutory-instruments\\/[a-zA-z0-9]{8}$/': {
+      '/^\\/$/': {
+        host: 'thorney.pdswebops.org',
+        port: 3000
+      },
+      '/^\\/groups\\/?$/': {
+        host: 'thorney.pdswebops.org',
+        port: 3000
+      },
+      '/^\\/groups\\/[a-zA-z0-9]{8}\\/?$/': {
+        host: 'thorney.pdswebops.org',
+        port: 3000
+      },
+      '/^\\/groups\\/[a-zA-z0-9]{8}/made-available/availability-types/layings\\/?$/': {
         host: 'thorney.pdswebops.org',
         port: 3000
       },
@@ -66,7 +102,7 @@ describe('routes', () => {
         host: 'thorney.pdswebops.org',
         port: 3000
       },
-      '/^\\/$/': {
+      '/^\\/statutory-instruments\\/[a-zA-z0-9]{8}\\/?$/': {
         host: 'thorney.pdswebops.org',
         port: 3000
       },


### PR DESCRIPTION
- Added routes for
  - `/groups/`
  - `/groups/:id`
  - `/groups/:id/made-available/availability-types/layings`

- Updated regex for route '/statutory-instruments/<8_character_alphanumeric_id>' to allow for a trailing slash